### PR TITLE
Prevent arrow keys from scrolling page

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -683,6 +683,7 @@ Custom property | Description | Default
             this.increment();
           }
           this.fire('change');
+          event.preventDefault();
         }
       },
 
@@ -694,6 +695,7 @@ Custom property | Description | Default
             this.decrement();
           }
           this.fire('change');
+          event.preventDefault();
         }
       },
 


### PR DESCRIPTION
Actual tested fix for issue #161 to prevent keys from scrolling the page in paper-slider.